### PR TITLE
GSI speedup, add the fix/ directory, bug fixes and others

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -50,7 +50,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/GSI.git
 # Specify either a branch name or a hash but not both.
 #branch = feature/rrfs
-hash = e25d4a6
+hash = c762340
 local_path = src/gsi
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -41,7 +41,7 @@ required = True
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/pygraf
-hash = 8d54d05
+hash = 18b3eae
 local_path = python_graphics
 required = True
 
@@ -59,7 +59,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl.git
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = 3d83052
+hash = 3087ea4
 local_path = src/rrfs_utl
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -6,8 +6,8 @@
 protocol = git
 repo_url = https://github.com/NOAA-GSL/regional_workflow
 # Specify either a branch name or a hash but not both.
-branch = 3DRTMA
-#hash = 608422bb
+#branch = 3DRTMA or 3DRTMA_rt
+hash = ed96a23
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -7,7 +7,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/regional_workflow
 # Specify either a branch name or a hash but not both.
 #branch = 3DRTMA or 3DRTMA_rt
-hash = ed96a23
+hash = 47e4a2d
 local_path = regional_workflow
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/ufs-weather-model
 # Specify either a branch name or a hash but not both.
 #branch = gsl/develop
-hash = 4c48f91
+hash = 50f90af
 local_path = src/ufs_weather_model
 required = True
 
@@ -41,7 +41,7 @@ required = True
 [python_graphics]
 protocol = git
 repo_url = https://github.com/NOAA-GSL/pygraf
-hash = 82a5318
+hash = 8d54d05
 local_path = python_graphics
 required = True
 
@@ -50,7 +50,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/GSI.git
 # Specify either a branch name or a hash but not both.
 #branch = feature/rrfs
-hash = c762340
+hash = 8d41072
 local_path = src/gsi
 required = True
 
@@ -59,7 +59,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl.git
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = d3e249e
+hash = 3d83052
 local_path = src/rrfs_utl
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -59,7 +59,7 @@ protocol = git
 repo_url = https://github.com/NOAA-GSL/rrfs_utl.git
 # Specify either a branch name or a hash but not both.
 # branch = develop
-hash = b935faa
+hash = d3e249e
 local_path = src/rrfs_utl
 required = True
 

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -1,36 +1,81 @@
 #!/bin/bash
 set -eu
 
+# Initialize and load modules
+if [[ -d /dcom && -d /hwrf ]] ; then
+    . /usrx/local/Modules/3.2.10/init/sh
+    PLATFORM=wcoss
+    . $MODULESHOME/init/sh
+elif [[ -d /cm ]] ; then
+    . $MODULESHOME/init/sh
+    PLATFORM=wcoss_c
+elif [[ -d /ioddev_dell ]]; then
+    . $MODULESHOME/init/sh
+    PLATFORM=wcoss_d
+elif [[ -d /scratch1 ]] ; then
+    . /apps/lmod/lmod/init/sh
+    PLATFORM=hera
+elif [[ -d /carddata ]] ; then
+    . /opt/apps/lmod/3.1.9/init/sh
+    PLATFORM=s4
+elif [[ -d /jetmon ]] ; then
+    . $MODULESHOME/init/sh
+    PLATFORM=jet
+elif [[ -d /glade ]] ; then
+    . $MODULESHOME/init/sh
+    PLATFORM=cheyenne
+elif [[ -d /sw/gaea ]] ; then
+    . /opt/cray/pe/modules/3.2.10.5/init/sh
+    PLATFORM=gaea
+elif [[ -d /work ]]; then
+    . $MODULESHOME/init/sh
+    PLATFORM=orion
+else
+    echo "unknown PLATFORM"
+    exit 9
+fi
+
 #cd to location of script
 MYDIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 
 usage () {
-  echo "Usage: "
-  echo "  $0 PLATFORM COMPILER"
+  echo -e "\nExample Usage: "
+  echo "  $0        (show this help)"
+  echo "  $0 intel  (build GSI using Intel compiler)"
+  echo "  $0 gnu    (build GSI using GNU compiler)"
+  echo "  $0 kjet   (build GSI using Intel compiler and kjet specfici optimization)"
+  echo "            ** kjet option should be used by real time deployment on Jet**   "
+  echo "  $0 help   (show this help)"
   echo ""
-  echo "PLATFORM: Name of machine you are building on"
-  echo "COMPILER: (optional) compiler to use; valid options are 'intel', 'gnu'"
+  echo " The build script will automatically determine current HPC platform."
+  echo " Don't use the 'kjet' optin if you will run GSI on other jet (such as xjet,etc) or you are not on Jet"
   echo ""
   echo "NOTE: This script is for internal developer use only;"
   echo "See User's Guide for detailed build instructions"
 }
 
-PLATFORM="${1:-NONE}"
-COMPILER="${2:-intel}"
-
-
-if [ $# -lt 1 ]; then 
-  echo "ERROR: not enough arguments"
-  usage
-  exit 1
-fi
-if [ $# -gt 2 ]; then
-  echo "ERROR: too many arguments"
-  usage
-  exit 1
-fi
-
-if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then 
+opt=${1:-""}
+COMPILER="intel"
+KJET=""
+if [[ ! -z $opt ]]; then
+  case $opt in
+    kjet|kJet|KJET|Kjet|kJET)
+      KJET="kjet"
+       ;;
+    --help|-h|help)
+      usage
+      exit 0
+      ;;
+    intel|gnu)
+     COMPILER="${opt}"
+      ;;
+    *)
+     echo -e "\n        unknown option: ${opt}"
+     usage
+     exit 0
+      ;;
+  esac
+else
   usage
   exit 0
 fi
@@ -74,7 +119,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=..
 make -j ${BUILD_JOBS:-4}
 
 cd ${MYDIR}/src/gsi
-./ush/build.comgsi
+./ush/build.comgsi ${KJET}
 cp ${MYDIR}/src/gsi/build/bin/gsi.x ${MYDIR}/bin/gsi.x
 
 . ${MYDIR}/${ENV_FILE}_DA

--- a/env/build_wcoss_dell_p3_intel.env
+++ b/env/build_wcoss_dell_p3_intel.env
@@ -36,9 +36,6 @@ module load w3nco/2.4.1
 module load upp/10.0.8
 
 module load gftl-shared/v1.3.0
-module load yafyaml/v0.5.1
-module load mapl/v2.7.3
-
 module load sfcio/1.4.1
 module load wgrib2/2.0.8
 

--- a/env/build_wcoss_dell_p3_intel.env_DA
+++ b/env/build_wcoss_dell_p3_intel.env_DA
@@ -32,6 +32,7 @@ module load w3emc/2.7.3
 module load bacio/2.4.1
 module load crtm/2.3.0
 module load netcdf/4.7.4
+module load wrf_io/1.2.0
 #
 #
 module load jasper/1.900.1

--- a/manage_externals/checkout_externals
+++ b/manage_externals/checkout_externals
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import os
 import sys
 import traceback
 
@@ -28,6 +29,8 @@ if __name__ == '__main__':
     ARGS = manic.checkout.commandline_arguments()
     try:
         RET_STATUS, _ = manic.checkout.main(ARGS)
+        if os.path.isfile('regional_workflow/Init.sh'):
+            os.system('regional_workflow/Init.sh')
         sys.exit(RET_STATUS)
     except Exception as error:  # pylint: disable=broad-except
         manic.printlog(str(error))

--- a/manage_externals/manic/externals_description.py
+++ b/manage_externals/manic/externals_description.py
@@ -253,7 +253,7 @@ def read_gitmodules_file(root_dir, file_name):
                                           ExternalsDescription.REPO_URL, url)
                 externals_description.set(sec_name,
                                           ExternalsDescription.REQUIRED, 'True')
-                git_hash = submods[sec_name]['hash']
+                git_hash = submods[path]['hash']
                 externals_description.set(sec_name,
                                           ExternalsDescription.HASH, git_hash)
 


### PR DESCRIPTION
< Changes here are mainly reflected by hash updates for different components >  

use 2 OMP threads, kjet specific optimization and parallel netcdf to speed up GSI run  
change cp_vrfy to ln_vrfy for GSI jobs  
changes in FV3LAM namelist
add $HYBENSMEM_NMIN which sets the minimum number of ensembles required for a hybrid GSI analysis
more control on wgrib2 jobs
clean up outdated variables in exregional_run_analysis.sh
turn off l2rw DA through gsiparm.anl
update devbuild.sh to be able to determine HPC platforms automatically
bug fixes on rrfs_utl, pygraf, gsi, etc.

Add the fix/ directory to regional_workflow
 - GSI  fix files under fix/gsi
 - UPP  fix files under fix/upp
 - CRTM fix files under fix/crtm
 - change scripts, config.sh*, etc accordingly
    
Add Init.sh   
 - initialize fix/ so that links to binary/large fix files work at different HPC platforms
 - install pre-commit git hook to prevent binary/large fix files themselves to be committed   

Add fix_rrfs_locations.sh   
 - set the FIX_RRFS locations at differnt HPC platforms          

AIRCRAFT_REJECT, SFCOBS_USELIST       
 - default to use fix files under FIX_GSI unless a path specified in config.sh       

Add $TESTBED_FIELDS_FN (files are under FIX_UPP)        
 - different testbed_fields files for different applications     
 - if empty string, no bgsfc output       